### PR TITLE
Replaces the old Expression class  with the htmlString class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "kim/defender",
-    "description": "Fend off spam bots by using randomized input names / honeypots.",
+    "name": "melvintehu/laravel-spam-protection",
+    "description": "Fend off spam bots by using randomized input names / honeypots. Credits go to thomastkim.",
     "keywords": [
         "laravel",
         "php",
@@ -11,9 +11,9 @@
     "license": "MIT",
     "authors": [
         {
-            "name": "Thomas Kim",
-            "email": "thomas@thomastkim.com",
-            "homepage": "http://thomastkim.com"
+            "name": "Melvintehu",
+            "email": "informatie@mentechmedia.nl",
+            "homepage": "https://mentechmedia.nl"
         }
     ],
     "require": {
@@ -21,6 +21,7 @@
         "illuminate/session": "~5.0",
         "illuminate/validation": "~5.0",
         "illuminate/view": "~5.0",
+        "Illuminate/Support/HtmlString": "~5.1",
         "php" : ">=5.4.0"
     },
     "require-dev": {

--- a/src/Kim/Defender/Laravel/DefenderHtmlGenerator.php
+++ b/src/Kim/Defender/Laravel/DefenderHtmlGenerator.php
@@ -43,7 +43,7 @@ class DefenderHtmlGenerator implements DefenderHtmlGeneratorContract
             $html .= '<input type="' . $this->getRandomType() . '" name="' . $token . '" style="' . $this->getRandomStyling() . '">';
         }
 
-        return new Expression($html);
+        return new HtmlString($html);
     }
 
     /**


### PR DESCRIPTION
htmlString is still a class in laravel 5.6 but is also present in laravel 5.1 - laravel 5.5. Do whatever you like with this pullrequest. If you think this bugfix shouldn't be in your code, than it's okay with me :).

Signed-off-by: Melvin Tehubijuluw <melvindrachten@hotmail.com>